### PR TITLE
fixed product image shown on supplies.show

### DIFF
--- a/app/Http/Controllers/SuppliesController.php
+++ b/app/Http/Controllers/SuppliesController.php
@@ -67,9 +67,9 @@ class SuppliesController extends Controller
         } else {
             $productImageName = time() . '-' . $request->productImage->getClientOriginalName();
             // $imgName = $request->file('productImage')->storeAs('img/product', $productImageName);
-            $imgName = $request->file('productImage')->storeAs('public/imgproduct', $productImageName);
+            $imgName = $request->file('productImage')->storeAs('public/img/product', $productImageName);
             // dd($imgName);
-            $publicPath = $request->productImage->move(public_path('img/product'), $productImageName);
+            // $publicPath = $request->productImage->move(public_path('img/product'), $productImageName);
     
             $supplies = new Supplies();
             $supplies->name = $request->productName;
@@ -191,31 +191,18 @@ class SuppliesController extends Controller
 
         $supplies = Supplies::findOrFail($id);
 
-        // if (Storage::disk('local')->exists('img/product/' . $supplies->image)) {
-        //     $imagePathFinder = Storage::disk('local')->path('img/product/' . $supplies->image);
-        //     // dd($imagePathFinder);
-        //     return 'file ' . $supplies->image . ' in disk';
-        // } else {
-        //     return 'file ' . $supplies->image . ' not in disk';
-        // }
-
         if ($supplies->image === NULL) {
             // return "no product image";
             return back()->with('notify', 'No Product Image');
         } 
         else {
-            // $supplies = Supplies::findOrFail($id);
-            // // $download = public_path('img/product/') . $supplies->image;
+            // if (Storage::disk('local')->exists('img/product/' . $supplies->image)) {
+            //     $imagePathFinder = Storage::disk('local')->path('img/product/' . $supplies->image);
             // $download = storage_path('app/img/product/') . $supplies->image;
-            // $headers = array(
-            //     'Content-Type: image/jpeg',
-            // );
-            // 
-            // return Response::download($download, 'productimage.jpg', $headers);
-            if (Storage::disk('local')->exists('img/product/' . $supplies->image)) {
-                $imagePathFinder = Storage::disk('local')->path('img/product/' . $supplies->image);
+            if (Storage::disk('local')->exists('public/img/product/' . $supplies->image)) {
+                $imagePathFinder = Storage::disk('local')->path('public/img/product/' . $supplies->image);
                 $supplies = Supplies::findOrFail($id);
-                $download = storage_path('app/img/product/') . $supplies->image;
+                $download = storage_path('app/public/img/product/') . $supplies->image;
                 $headers = array(
                     'Content-Type: image/jpeg',
                 );
@@ -224,6 +211,8 @@ class SuppliesController extends Controller
                 // return back()->with('notFound', 'Sorry. Image not found');
             }
             return back()->with('notFound', 'Sorry. Image may not exist.');
+            // refer to config/filesystems.php for info about disk('local')
+            // checks the storage/app/public/img/product/$supplies->image if the image exists
         }
     }
 }

--- a/resources/views/supplies/show.blade.php
+++ b/resources/views/supplies/show.blade.php
@@ -58,9 +58,10 @@
                         Product does not have an image.
                     </div>
                 @else
-                {{ $supplies->image }}
-                    <img src="{{ asset('imgproduct/'.$supplies->image) }}" alt="Product image from storage"
+                    <img src="{{ asset('storage/img/product/'.$supplies->image) }}" alt="Product image from storage"
                         style="height:150px" class="rounded mx-auto d-block">
+                        <!-- will look into public/storage/img/product/theImage -->
+                        <!-- this is because of the connection link using php artisan storage:link -->
                     <br>
                     <a href="{{ route('supplies.downloadimage', $supplies->id) }}" class="btn btn-outline-primary">Download Image</a>
                     <p> {{ session('notify') }} </p>


### PR DESCRIPTION
-used php artisan storage:link to link storage and public 
-image uploaded will go to storage/app/public/img/product/imageUploaded 
-will check local disk(storage/app/public/img/product/..) if image exists 
-the downloaded img will come from localdisk(reference above) 
-fixed path(public/storage/img/product/theImage) of where to look for the image on supplies.show -- .gitignore